### PR TITLE
Remove Bower from Grunt

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,11 +16,6 @@ module.exports = function (grunt) {
             // configurable paths
             app: require('./bower.json').publicPath || 'public'
         },
-        bower: {
-            install: {
-                //just run 'grunt bower:install' and you'll see files from your Bower packages in lib directory
-            }
-        },
         jshint: {
             options: {
                 jshintrc: '.jshintrc',
@@ -127,14 +122,12 @@ module.exports = function (grunt) {
     });
 
     grunt.registerTask('dev', [
-        'bower',
         'express:dev',
         'open',
         'watch'
     ]);
 
     grunt.registerTask('ui-dev', [
-        'bower',
         'sass',
         'express:dev',
         'open',
@@ -142,21 +135,14 @@ module.exports = function (grunt) {
     ]);
 
     grunt.registerTask('test', [
-        'bower',
         'concurrent:test'
     ]);
 
-    grunt.registerTask('heroku:production', [
-        'bower'
-    ]);
-
+    // TODO: define this task
     grunt.registerTask('default', [
-        //  'jshint',
-        'bower'
     ]);
 
     grunt.registerTask('e2e-tests', [
-        'bower',
         'express:dev',
         'open',
         'protractor'

--- a/README.md
+++ b/README.md
@@ -1,27 +1,31 @@
 [![Stories in Ready](https://badge.waffle.io/MakingSense/mean-seed.png?label=ready&title=Ready)](https://waffle.io/MakingSense/mean-seed)
 MEAN-seed  
-================
+=========
 
-A bootstrapp application based on MongoDB, Express, Angular, Node, Passport
- 
-### Setup:
+A bootstrapp application based on MongoDB, Express, Angular, Node, Passport.
+
+### Requirements
+
+- Node and NPM
+- Bower
+- Grunt client
+
+### Setup
+
 ```
 npm install
-npm install -g bower
-npm install -g grunt-cli
-bower install --allow-root
 ```
-read more about installing [Bower](http://bower.io/) and [Grunt client](http://gruntjs.com/getting-started)
 
-### Installing MongoDB:
+Read more about installing [Node](https://nodejs.org/download/), [Bower](http://bower.io/) and [Grunt client](http://gruntjs.com/getting-started).
+
+### Installing MongoDB
 
 Go to [MongoDB official downloads](http://www.mongodb.org/downloads) and follow the [instructions](http://docs.mongodb.org/manual/installation/)
 
-### Running the app for development:
-Run 
-```grunt dev```
-to start the app in development mode with client-server livereload. (Remember to have the mongoDB running)
+### Running the app for development
+
+Run ```grunt dev``` to start the app in development mode with client-server livereload. (Remember to have the mongoDB running)
 
 ### Testing
+
 Run ```grunt test``` to start the karma test runner.
- 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "mean-seed",
-    "version": "0.0.0",
+    "version": "0.0.1",
     "dependencies": {
         "angular": "~1.2.1",
         "json3": "~3.2.4",
@@ -13,8 +13,8 @@
         "angular-route": "~1.2.0",
         "angular-http-auth": "*",
         "angular-bootstrap": "~0.7.0",
-        "autofill-directive":"~2.0.0",
-        "underscore":"~1.5.2",
+        "autofill-directive": "~2.0.0",
+        "underscore": "~1.5.2",
         "ngstorage": "0.3.0"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,48 +1,54 @@
 {
-  "name": "mean-seed",
-  "version": "0.0.1",
-  "dependencies": {
-    "express": "~3.4.3",
-    "mongoose": "~3.5.5",
-    "ejs": "~0.8.4",
-    "underscore": "~1.5.2",
-    "connect-mongo": "~0.4.0",
-    "app-module-path": "^0.3.2-beta",
-    "jsonwebtoken": "5.0.2"
-  },
-  "devDependencies": {
-    "grunt": "~0.4.1",
-    "grunt-bower-task": "~0.3.4",
-    "grunt-cli": "0.1.13",
-    "grunt-concurrent": "~0.5.0",
-    "grunt-contrib-jshint": "*",
-    "grunt-contrib-watch": "~0.5.2",
-    "grunt-express-server": "~0.4.5",
-    "grunt-karma": "~0.6.2",
-    "grunt-mocha-istanbul": "^2.4.0",
-    "grunt-mocha-test": "^0.12.7",
-    "grunt-open": "~0.2.0",
-    "grunt-protractor-runner": "^2.0.0",
-    "grunt-sass": "*",
-    "istanbul": "^0.3.15",
-    "jshint-stylish": "~0.1.3",
-    "karma": "0.10.9",
-    "karma-chrome-launcher": "~0.1.0",
-    "karma-coffee-preprocessor": "~0.1.0",
-    "karma-firefox-launcher": "~0.1.0",
-    "karma-html2js-preprocessor": "~0.1.0",
-    "karma-jasmine": "~0.1.3",
-    "karma-ng-html2js-preprocessor": "~0.1.0",
-    "karma-ng-scenario": "~0.1.0",
-    "karma-phantomjs-launcher": "~0.1.0",
-    "karma-requirejs": "~0.2.0",
-    "karma-script-launcher": "~0.1.0",
-    "load-grunt-tasks": "~0.2.0",
-    "mocha": "^2.2.5",
-    "should": "^6.0.3",
-    "sinon": "^1.15.3"
-  },
-  "engines": {
-    "node": ">=0.8.0"
-  }
+    "name": "mean-seed",
+    "version": "0.0.1",
+    "repository": { 
+        "type": "git",
+        "url": "https://github.com/MakingSense/mean-seed"
+    },
+    "dependencies": {
+        "express": "~3.4.3",
+        "mongoose": "~3.5.5",
+        "ejs": "~0.8.4",
+        "underscore": "~1.5.2",
+        "connect-mongo": "~0.4.0",
+        "app-module-path": "^0.3.2-beta",
+        "jsonwebtoken": "5.0.2"
+    },
+    "devDependencies": {
+        "grunt": "~0.4.1",
+        "grunt-cli": "0.1.13",
+        "grunt-concurrent": "~0.5.0",
+        "grunt-contrib-jshint": "*",
+        "grunt-contrib-watch": "~0.5.2",
+        "grunt-express-server": "~0.4.5",
+        "grunt-karma": "~0.6.2",
+        "grunt-mocha-istanbul": "^2.4.0",
+        "grunt-mocha-test": "^0.12.7",
+        "grunt-open": "~0.2.0",
+        "grunt-protractor-runner": "^2.0.0",
+        "grunt-sass": "*",
+        "istanbul": "^0.3.15",
+        "jshint-stylish": "~0.1.3",
+        "karma": "0.10.9",
+        "karma-chrome-launcher": "~0.1.0",
+        "karma-coffee-preprocessor": "~0.1.0",
+        "karma-firefox-launcher": "~0.1.0",
+        "karma-html2js-preprocessor": "~0.1.0",
+        "karma-jasmine": "~0.1.3",
+        "karma-ng-html2js-preprocessor": "~0.1.0",
+        "karma-ng-scenario": "~0.1.0",
+        "karma-phantomjs-launcher": "~0.1.0",
+        "karma-requirejs": "~0.2.0",
+        "karma-script-launcher": "~0.1.0",
+        "load-grunt-tasks": "~0.2.0",
+        "mocha": "^2.2.5",
+        "should": "^6.0.3",
+        "sinon": "^1.15.3"
+    },
+    "scripts": {
+		"postinstall": "bower install"
+	},
+    "engines": {
+        "node": ">=0.8.0"
+    }
 }


### PR DESCRIPTION
Hey guys! Could you take a look?

Bower install based on Grunt was failing so I decided to remove it from there and simplify it by adding it to `postinstall` at package.json. I believe this is nicer but we could discuss it anyways if someone has a better approach.

I have updated package.json and bower.json and docs with a few related modifications too.

Please let me know for any issue and thing you consider this could be improved. Thanks.